### PR TITLE
Tackle Sprint 1 tech debt: security, dead auth scaffold, and cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Copy this file to .env and fill in real values.
 # Generate SECRET_KEY with: python -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=replace-with-a-cryptographically-random-value
+
+# Use 'development' locally, 'production' on Cloud Run
+FLASK_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in real values.
+# Generate SECRET_KEY with: python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=replace-with-a-cryptographically-random-value

--- a/.flake8
+++ b/.flake8
@@ -1,15 +1,11 @@
 [flake8]
-extend-ignore = 
+extend-ignore =
     E203,  # Whitespace before ':'
     E704,  # Multiple statements on one line (def)
     W293,  # Blank line contains whitespace
     W292,  # No newline at end of file
     W291,  # Trailing whitespace
-    F401,  # Module imported but unused
-    E501,  # Line too long (82 > 79 characters)
-    F841,  # Local variable name is assigned to but never used
     E302,  # Expected 2 blank lines, found 1
-    E222,  # Multiple spaces after operator
-    E402   # Module level import not at top of file
+    E222   # Multiple spaces after operator
 exclude = .venv, tests
-max-line-length = 180
+max-line-length = 120

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,15 +2,11 @@ import logging
 import os
 
 from dotenv import load_dotenv
-from flask import Flask
+from flask import Flask, render_template
+
+from core.config import config as app_config
 
 load_dotenv()
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    datefmt="%Y-%m-%d",
-    format="%(levelname)s - %(message)s"
-)
 
 
 def register_blueprints(app):
@@ -20,8 +16,18 @@ def register_blueprints(app):
     Flask blueprints enable more modular HTML / code development
     """
 
-    from core.home.home import index_bp
+    from core.home.home import index_bp  # noqa: E402
     app.register_blueprint(index_bp)
+
+
+def register_error_handlers(app):
+    @app.errorhandler(404)
+    def not_found(e):
+        return render_template('home/404.html'), 404
+
+    @app.errorhandler(500)
+    def server_error(e):
+        return render_template('home/500.html'), 500
 
 
 def create_app(env=''):
@@ -31,11 +37,21 @@ def create_app(env=''):
 
     app = Flask(__name__)
 
+    env = env or os.environ.get('FLASK_ENV', 'production')
+    app.config.from_object(app_config.get(env, app_config['default']))
+
     secret_key = os.environ.get('SECRET_KEY')
     if not secret_key:
         raise RuntimeError("SECRET_KEY environment variable is not set")
     app.secret_key = secret_key
 
+    logging.basicConfig(
+        level=app.config['LOG_LEVEL'],
+        datefmt="%Y-%m-%d",
+        format="%(levelname)s - %(message)s"
+    )
+
     register_blueprints(app)
+    register_error_handlers(app)
 
     return app

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,15 +1,17 @@
 import logging
-from flask import Flask
-from flask_login import LoginManager
-from core.models import db, User
+import os
 
-login_manager = LoginManager()
+from dotenv import load_dotenv
+from flask import Flask
+
+load_dotenv()
 
 logging.basicConfig(
     level=logging.DEBUG,
     datefmt="%Y-%m-%d",
     format="%(levelname)s - %(message)s"
 )
+
 
 def register_blueprints(app):
     """
@@ -29,17 +31,11 @@ def create_app(env=''):
 
     app = Flask(__name__)
 
-    app.secret_key = 'dev_test'  # Can be anything; 
-    register_blueprints(app)
-    
-    login_manager.init_app(app)
-    login_manager.login_view = 'auth.login'
+    secret_key = os.environ.get('SECRET_KEY')
+    if not secret_key:
+        raise RuntimeError("SECRET_KEY environment variable is not set")
+    app.secret_key = secret_key
 
-    @login_manager.user_loader
-    def load_user(user_id):
-        try:
-            return User.query.get(int(user_id))
-        except Exception as err:
-            logging.debug(f"Issue getting user_id: {err}")
-            return None
+    register_blueprints(app)
+
     return app

--- a/core/app.py
+++ b/core/app.py
@@ -1,6 +1,6 @@
-from flask import Flask
 from core import create_app
 
-
 app = create_app()
-# app.run(host="127.0.0.1", port=8080, debug=True)
+
+if __name__ == '__main__':
+    app.run(host='127.0.0.1', port=8080, debug=True)

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,20 @@
+class Config:
+    DEBUG = False
+    TESTING = False
+    LOG_LEVEL = 'WARNING'
+
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+    LOG_LEVEL = 'DEBUG'
+
+
+class ProductionConfig(Config):
+    pass
+
+
+config = {
+    'development': DevelopmentConfig,
+    'production': ProductionConfig,
+    'default': DevelopmentConfig,
+}

--- a/core/home/templates/home/404.html
+++ b/core/home/templates/home/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+{% include 'home/includes/header.html' %}
+{% include 'home/includes/themes.html' %}
+
+<body>
+    {% include 'home/core/navigation.html' %}
+
+    <main style="display:flex; flex-direction:column; align-items:center; justify-content:center; min-height:80vh; text-align:center; padding:2rem;">
+        <h1 style="font-size:6rem; font-weight:700; margin:0; opacity:0.15;">404</h1>
+        <h2 style="font-size:1.5rem; font-weight:500; margin:1rem 0 0.5rem;">Page not found</h2>
+        <p style="opacity:0.6; margin-bottom:2rem;">The page you're looking for doesn't exist.</p>
+        <a href="{{ url_for('index.index') }}" class="btn-primary">Go home</a>
+    </main>
+
+    {% include 'home/includes/footer.html' %}
+    {% include 'home/includes/scripts.html' %}
+</body>
+</html>

--- a/core/home/templates/home/500.html
+++ b/core/home/templates/home/500.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+{% include 'home/includes/header.html' %}
+{% include 'home/includes/themes.html' %}
+
+<body>
+    {% include 'home/core/navigation.html' %}
+
+    <main style="display:flex; flex-direction:column; align-items:center; justify-content:center; min-height:80vh; text-align:center; padding:2rem;">
+        <h1 style="font-size:6rem; font-weight:700; margin:0; opacity:0.15;">500</h1>
+        <h2 style="font-size:1.5rem; font-weight:500; margin:1rem 0 0.5rem;">Something went wrong</h2>
+        <p style="opacity:0.6; margin-bottom:2rem;">An unexpected error occurred. Please try again shortly.</p>
+        <a href="{{ url_for('index.index') }}" class="btn-primary">Go home</a>
+    </main>
+
+    {% include 'home/includes/footer.html' %}
+    {% include 'home/includes/scripts.html' %}
+</body>
+</html>

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -6,8 +6,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
 
-# Import data models & mixins
-# from .mixins import TimestampMixin
+# Import data models
 from .user import User
 
 

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -3,7 +3,6 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import UserMixin
 
 from . import db
-# from .mixins import TimestampMixin
 
 
 class User(db.Model, UserMixin):

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,0 +1,1 @@
+# Shared utility functions go here.


### PR DESCRIPTION
## Summary

- **Issue 1 (Security, P45):** Replace hardcoded `secret_key = 'dev_test'` with `SECRET_KEY` loaded from environment via `python-dotenv`. Raises `RuntimeError` at startup if unset so it can never silently run in production without a real key. Added `.env.example` with generation instructions.
- **Issue 3 (Bug, P25):** Resolved as a side-effect of Issue 4 — the deprecated `User.query.get()` call was inside the now-removed `load_user` function.
- **Issue 4 (Architecture, P24):** Removed the entire dead auth scaffold from `core/__init__.py` — `LoginManager`, `db`/`User` imports, `login_manager.init_app()`, and `load_user`. None of it was functional (`db.init_app()` was never called, `auth` blueprint never existed).
- **Issue 11 (Cleanup, P10):** Added `core/utils/__init__.py` to make the package importable and signal intent.
- **Issue 12 (Cleanup, P10):** Removed `TimestampMixin` comment references in `core/models/`; replaced commented-out `app.run` with a proper `if __name__ == '__main__':` guard in `core/app.py`.

## Test plan

- [x] Create a `.env` from `.env.example` with a real `SECRET_KEY` and confirm the app starts
- [x] Confirm the app raises `RuntimeError` when `SECRET_KEY` is absent
- [x] Verify `/` returns 200 and the portfolio renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)